### PR TITLE
Created two different Constructors

### DIFF
--- a/entropy/kde.py
+++ b/entropy/kde.py
@@ -4,7 +4,7 @@ part of the entroPy module
 @author: paq
 """
 import numpy as np
-from entropy.kde_kernel import __kde_kernel as kernel
+from entropy.kde_kernel import _kde_kernel
 from .resolution import process_resolution_argument
 
 
@@ -54,14 +54,14 @@ class kde(object):
 
         if verbose:
             print("Initializing C++ kernel for kde...")
-        k = kernel(self.data, self.resolution)
-        k.calculate()
+        kernel = _kde_kernel(self.data, self.resolution)
+        kernel.calculate()
         self.set_is_finished(True)
         if verbose:
             print("KDE finished.")
-        self.set_pdf_x(center_grid(k.get_grid()))
-        self.set_bandwidth(k.get_bandwidth())
-        self.set_pdf(k.get_pdf())
+        self.set_pdf_x(center_grid(kernel.get_grid()))
+        self.set_bandwidth(kernel.get_bandwidth())
+        self.set_pdf(kernel.get_pdf())
 
     # Getter #
     def get_resolution(self):

--- a/entropy/kde_kernel/kde_kernel.pyx
+++ b/entropy/kde_kernel/kde_kernel.pyx
@@ -10,6 +10,7 @@ cdef extern from "../../src/kde.cpp":
 cdef extern from "../../src/kde.h":
     cdef cppclass Gce:
         Gce(vector[double]&, int) except +
+        Gce(vector[double]&, vector[double] &, int) except +
 
         void calculate() except +
         double integrate(string &, double, double) except +
@@ -20,17 +21,20 @@ cdef extern from "../../src/kde.h":
         double getBandwidth()
 
 @cython.embedsignature(True)
-cdef class __kde_kernel:
+cdef class _kde_kernel:
     """
     This is a Docstring.
     """
-    def __init__(self, data, resolution):
+    def __init__(self, data, resolution, weights=None):
         pass
 
     cdef Gce* m_gce_kernel
-
-    def __cinit__(self, vector[double] data, int resolution):
-        self.m_gce_kernel = new Gce(data, resolution)
+    
+    def __cinit__(self, data, resolution, weights=None):
+        if weights:
+            self.m_gce_kernel = new Gce(data, weights, resolution)
+        else:
+            self.m_gce_kernel = new Gce(data, resolution)
     
     def __dealloc__(self):
         del self.m_gce_kernel
@@ -42,7 +46,7 @@ cdef class __kde_kernel:
         return self.m_gce_kernel.integrate(method.encode("utf-8"), start, end)
     
     def calculate_entropy(self, start, end, method="Simpson"):
-        return self.m_gce_kernel.entropy(method, start, end)
+        return self.m_gce_kernel.entropy(method.encode("utf-8"), start, end)
 
     def get_grid(self):
         return np.array(self.m_gce_kernel.getCenters())

--- a/src/Exceptions.h
+++ b/src/Exceptions.h
@@ -9,7 +9,7 @@ class UnknownIntegrator : std::runtime_error
 
 public:
   UnknownIntegrator(const std::string& err_msg)
-  : std::runtime_error{ "Error: Unknown Integrator: " + err_msg }
+  : std::runtime_error{ "UnknownIntegrator: " + err_msg }
   {}
 };
 
@@ -17,7 +17,7 @@ class IntegrationError : std::runtime_error
 {
 public:
   IntegrationError(const std::string& err_msg)
-  : std::runtime_error{ "Integration Error: " + err_msg }
+  : std::runtime_error{ "IntegrationError: " + err_msg }
   {}
 };
 
@@ -25,6 +25,14 @@ class EmptyListError : std::runtime_error
 {
 public:
   EmptyListError(const std::string& err_msg)
-  : std::runtime_error{ "Empty List Error: " + err_msg }
+  : std::runtime_error{ "EmptyListError: " + err_msg }
   {}
+};
+
+class ValueError : std::runtime_error
+{
+public:
+    ValueError(const std::string& err_msg)
+    : std::runtime_error{ "ValueError: " + err_msg }
+    {}
 };

--- a/src/kde.h
+++ b/src/kde.h
@@ -28,17 +28,20 @@ private:
 	std::vector<double> m_histogram;
 	std::vector<double> m_angles;
 	std::vector<double> m_densityEstimation;
-	void dct(double *, double  *);
-	void idct(double *, double  *);
 	double fixedpoint(const std::vector<double> &, const std::vector<double> &);
 	std::pair<double, double> extrema(const std::vector<double> &) const noexcept;
 	double csiszar(double, int, const std::vector<double>&, const std::vector<double>&) const noexcept;
     double calcIntPow(double, int) const noexcept;
+    double calcHistogramNormalizer(int) const;
+    double calcHistogramNormalizer(const std::vector<double>&) const;
+    void calculateHistogram( double histogramNormalizer, const std::vector<double>& weights );
 public:
 	Gce(double *, int, int);
 	Gce(const std::vector<double>&, int);
     Gce(const std::vector<double>& histogram, const std::vector<double>& xGrid, int res);
 
+    void dct(double *, double  *);
+	void idct(double *, double  *);
 	void calculate(void);
 	double integrate(const std::string &, double, double);
     double entropy(const std::string &type, double min, double max);

--- a/tests_cpp/Gce_Tester.cpp
+++ b/tests_cpp/Gce_Tester.cpp
@@ -28,5 +28,16 @@ TEST(GceTest, CalculateTest)
   gce.calculate();
   ASSERT_EQ(gce.getDensityEstimation().size(), 10);
   EXPECT_DOUBLE_EQ(gce.getDensityEstimation()[0] / gce.getDensityEstimation()[4], 0.5);
-  EXPECT_DOUBLE_EQ(gce.integrate("Simpson", 0.0, 1.0), 0.74242424242424232);
+  EXPECT_DOUBLE_EQ(gce.integrate("Simpson", -0.1, 1.1), 1.0);
+}
+
+TEST(GceTest, WeightsTest)
+{
+    Gce gce{ {0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0}, {1, 1, 1, 1, 1, 2, 1, 1, 1, 1, 1}, 10};
+    Gce gce2{ {0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0}, 10};
+    gce.calculate();
+    gce2.calculate();
+    EXPECT_DOUBLE_EQ(gce.integrate("Simpson", 0.0, 1.0), gce2.integrate("Simpson", 0.0, 1.0));
+
+    EXPECT_THROW(Gce( {0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0}, {1, 1, 1, 1, 1, 2, 1, 1, 1, 1}, 10), ValueError);
 }


### PR DESCRIPTION
The KDE can now be calculated using the data and weights. This is useful
for, i.e., the calculation of dihedral entropies with reweighting from
aMD, where the different dihedral configurations are associated with a
boost value, which disturbs the original energy surface.