### PR TITLE
Fix dihedral data shapes

### DIFF
--- a/examples/XEntropy_example0_artificial_binodal_distribution.ipynb
+++ b/examples/XEntropy_example0_artificial_binodal_distribution.ipynb
@@ -266,7 +266,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Feel free to try with oder data"
+    "# Feel free to try with other data"
    ]
   },
   {

--- a/package/xentropy/dihedrals.py
+++ b/package/xentropy/dihedrals.py
@@ -95,14 +95,11 @@ class dihedralEntropy(object):
         if self.has_weights:
             if verbose:
                 print("Weights have been given for the calculation of the histograms.")
-            iterable = zip(self.data, self.weights)
-        else:
-            iterable = zip(self.data, np.full(len(self.data), None))
 
         bws, pdf_xs, pdfs, ents = [], [], [], []
-        for dat, ws in iterable:
+        for dat in self.data:
             # apply periodic copies here
-            dat, ws = preprocess_dihedral_data(dat, ws, self.has_weights)
+            dat, ws = preprocess_dihedral_data(dat, self.weights, self.has_weights)
             # depending on whether weights are None or not, you will get a weighted pdf or a simple pdf
             kernel = _kde_kernel(dat, self.resolution, ws)
             kernel.calculate()

--- a/package/xentropy/internal/pre_post_processing.py
+++ b/package/xentropy/internal/pre_post_processing.py
@@ -1,4 +1,5 @@
 import numpy as np
+import warnings
 
 
 def reshape_arrays_eventually(some_array):
@@ -98,9 +99,9 @@ def process_data_shapes(data, weights=None, weight_switch=True):
         if data.shape[0] > data.shape[1]:
             warn_msg = "Your input data has suspicious shape. First dim is expected to be smaller than second dim. " \
                        "Data should have shape: (N_features, N_frames)."
-            raise RuntimeWarning(warn_msg)
-        pass  # This ia all good
-    else:
+            warnings.warn(warn_msg, RuntimeWarning)  # potentially transposed data
+        pass  # This is all good
+    else:  # This 3 dim or higher...
         err_msg = "Shape of data is suspicious\n" \
                   "{}".format(data.shape)
         raise ValueError(err_msg)

--- a/package/xentropy/internal/pre_post_processing.py
+++ b/package/xentropy/internal/pre_post_processing.py
@@ -75,7 +75,7 @@ def sanity_check_input_data(data, weights=None, weight_switch=True):
         if False in np.isfinite(weights):
             err_msg = "Non-finite values in weights!"
             raise ValueError(err_msg)
-        if data.shape != weights.shape:
+        if data.shape[-1] != weights.shape[-1]:
             err_msg = "Shapes of data and weights is inconsistent!\n" \
                       "data: {}, weights: {}".format(data.shape, weights.shape)
             raise ValueError(err_msg)
@@ -92,7 +92,8 @@ def process_data_shapes(data, weights=None, weight_switch=True):
     elif len(data.shape) == 1:
         data = np.array([data])
         if weight_switch:
-            weights = np.array([weights])
+            weights = np.array(weights)
+            # this is as good as pass...
     elif len(data.shape) == 2:
         pass  # This ia all good
     else:

--- a/package/xentropy/internal/pre_post_processing.py
+++ b/package/xentropy/internal/pre_post_processing.py
@@ -61,7 +61,7 @@ def postprocess_dihedral_pdf(pdf, pdf_x, norm_for_mirrored_data=1/3):
     pdf_out = pdf[lower_idx:upper_idx]
     pdf_out /= norm_for_mirrored_data  # we normalized in the "mirrored data", which is 3 times the actual data
     pdf_x_out = pdf_x[lower_idx:upper_idx]
-    assert len(pdf_out)==len(pdf_x_out)
+    assert len(pdf_out) == len(pdf_x_out)
     return pdf_out, pdf_x_out
 
 
@@ -95,6 +95,10 @@ def process_data_shapes(data, weights=None, weight_switch=True):
             weights = np.array(weights)
             # this is as good as pass...
     elif len(data.shape) == 2:
+        if data.shape[0] > data.shape[1]:
+            warn_msg = "Your input data has suspicious shape. First dim is expected to be smaller than second dim. " \
+                       "Data should have shape: (N_features, N_frames)."
+            raise RuntimeWarning(warn_msg)
         pass  # This ia all good
     else:
         err_msg = "Shape of data is suspicious\n" \

--- a/package/xentropy/kde.py
+++ b/package/xentropy/kde.py
@@ -8,6 +8,13 @@ from xentropy.kde_kernel import _kde_kernel
 from .internal.resolution import process_resolution_argument
 from .internal.pre_post_processing import sanity_check_input_data, process_weights_argument, reshape_arrays_eventually
 
+def check_dims(data):
+    data = np.squeeze(data)
+    if len(np.shape(data))>1:
+        err_msg = "Kde is designed for single data sets only!\n" \
+                  "You provided data of the following shape\n" \
+                  "data: {}".format(data.shape)
+        raise ValueError(err_msg)
 
 class kde(object):
 
@@ -22,6 +29,7 @@ class kde(object):
         weights, weight_switch = process_weights_argument(weights, verbose=verbose)
         self.__has_weights = weight_switch
         sanity_check_input_data(data, weights, weight_switch)
+        check_dims(data)  # kde can only take single data sets currently
         self.__data = data
         self.__weights = weights
         self.__verbose = verbose

--- a/package/xentropy/reweighting.py
+++ b/package/xentropy/reweighting.py
@@ -11,7 +11,7 @@ def maclaurin_series(xs, mac_order=10):
     Parameters
     ----------
     xs: array of floats
-    mc_order: int
+    mac_order: int
         max order for the Maclaurin series
 
     Returns
@@ -22,7 +22,7 @@ def maclaurin_series(xs, mac_order=10):
     return np.sum([xs ** i / np.math.factorial(i) for i in np.arange(mac_order+1)], axis=0)
 
 
-def calculate_amd_weight_maclau(boostEne, mac_order=10, T=300.0, id_gas=id_gas_SI):
+def calculate_amd_weight_maclau(boost_ene, mac_order=10, T=300.0, id_gas=id_gas_SI):
     """Calculate weights from aMD simulation boost energies for histogram
     reweighing using Maclaurin series expansion (see https://doi.org/10.1021/ct500090q).
 
@@ -30,7 +30,7 @@ def calculate_amd_weight_maclau(boostEne, mac_order=10, T=300.0, id_gas=id_gas_S
     -----------------------------
     boostEne: list(list(float))
         Boost energies from the aMD simulation
-    mc_order: int, optional
+    mac_order: int, optional
         The order of the Maclaurin series (default is 10)
     T: float, optional
         The simulation temperature, used to calculate the Boltzmann factor from the energies (default is 300.0)
@@ -42,7 +42,7 @@ def calculate_amd_weight_maclau(boostEne, mac_order=10, T=300.0, id_gas=id_gas_S
     Weights for the histogram calculation
     """
 
-    scaled_biasE = np.array(boostEne) / (T * id_gas)
+    scaled_biasE = np.array(boost_ene) / (T * id_gas)
     # MCweight = np.zeroslike(boostEne)
     # for x in range(mc_order+1):
     #     MCweight = np.add(MCweight, (np.divide(np.power(boostEne, x), math.factorial(x))))
@@ -51,16 +51,15 @@ def calculate_amd_weight_maclau(boostEne, mac_order=10, T=300.0, id_gas=id_gas_S
     return non_norm_weights/np.sum(non_norm_weights)
 
 
-def calculate_amd_weight_exp(boostEne, T=300.0, id_gas=id_gas_kcal):
+def calculate_amd_weight_exp(boost_ene, T=300.0, id_gas=id_gas_kcal):
     """Calculate weights from aMD simulation boost energies for histogram
-    reweighing using Maclaurin series expansion (see https://doi.org/10.1021/ct500090q).
+    reweighing using exponential function.
 
     Paramteres:
     -----------------------------
     boostEne: list(list(float))
         Boost energies from the aMD simulation
-    mc_order: int, optional
-        The order of the Maclaurin series (default is 10)
+
     T: float, optional
         The simulation temperature, used to calculate the Boltzmann factor from the energies (default is 300.0)
     kb: float, optional
@@ -70,10 +69,8 @@ def calculate_amd_weight_exp(boostEne, T=300.0, id_gas=id_gas_kcal):
     -----------------------------
     Weights for the histogram calculation
     """
-    # TODO
-    print("WIP")
 
-    # scaled_biasE = np.array(boostEne) / (T * kb)
-    #
-    # return maclaurin_series(scaled_biasE, mac_order=mac_order)
-    pass
+    scaled_biasE = np.array(boost_ene) / (T * id_gas)
+
+    non_norm_weights = np.exp(scaled_biasE)
+    return non_norm_weights/np.sum(non_norm_weights)

--- a/package/xentropy/xentropy.py
+++ b/package/xentropy/xentropy.py
@@ -88,14 +88,11 @@ class Entropy(object):
         if self.has_weights:
             if verbose:
                 print("Weights have been given for the calculation of the histograms.")
-            iterable = zip(self.data, self.weights)
-        else:
-            iterable = zip(self.data, np.full(len(self.data), None))
 
         bws, pdf_xs, pdfs, ents = [], [], [], []
-        for dat, ws in iterable:
+        for dat in self.data:
             # depending on whether weights are None or not, you will get a weighted pdf or a simple pdf
-            kernel = _kde_kernel(dat, self.resolution, ws)
+            kernel = _kde_kernel(dat, self.resolution, self.weights)
             kernel.calculate()
 
             bws.append(kernel.get_bandwidth())


### PR DESCRIPTION
This is mostly about data shapes in all kinds of modules, but some minor additional things have been squeezed in here as well.
Most of this is actually many weeks old, but the rebase was totally free of conflicts. Tested it a little and to me it looks fine...


- Check for potentially transposed data
- one set of weights for N sets of dihedrals
- comprehensive error message, that kde module only takes single data sets currently
- type in tutorial
- exp. reweighting (totally unrelated to the rest of the merge)