### PR TITLE
Check for negative weights

### DIFF
--- a/package/xentropy/dihedrals.py
+++ b/package/xentropy/dihedrals.py
@@ -12,7 +12,7 @@ from .internal.resolution import process_resolution_argument, rules_of_thumb_dih
 
 from .internal.pre_post_processing import preprocess_dihedral_data, process_data_shapes, \
     process_weights_argument, process_method_argument, reshape_arrays_eventually, postprocess_dihedral_pdf, \
-    rad_to_deg, deg_to_rad
+    rad_to_deg, deg_to_rad, sanity_check_input_data
 from .internal.constants import id_gas_SI, PI
 import warnings
 

--- a/package/xentropy/dihedrals.py
+++ b/package/xentropy/dihedrals.py
@@ -34,6 +34,7 @@ class dihedralEntropy(object):
                                                         rules_of_thumb=rules_of_thumb_dihedral())
         # process input arrays
         weights, weight_switch = process_weights_argument(weights, verbose=verbose)
+        sanity_check_input_data(data, weights, weight_switch)
         self.__has_weights = weight_switch
         data, weights = process_data_shapes(data, weights, weight_switch)
         self.__data = data

--- a/package/xentropy/internal/pre_post_processing.py
+++ b/package/xentropy/internal/pre_post_processing.py
@@ -115,7 +115,6 @@ def sanity_check_input_data(data, weights=None, weight_switch=True):
 
 def process_data_shapes(data, weights=None, weight_switch=True):
     data = np.array(data)
-    sanity_check_input_data(data, weights, weight_switch)
 
     if len(data.shape) == 0:
         err_msg = "Shape of data is suspicious\n" \

--- a/package/xentropy/internal/pre_post_processing.py
+++ b/package/xentropy/internal/pre_post_processing.py
@@ -29,6 +29,9 @@ def process_weights_argument(weights, verbose=False):
         if verbose:
             print("Weights have been given.")
         weights = np.array(weights)
+        if True in (weights < 0):
+            err_msg = "You gave negative values in you weights array.\n"
+            raise ValueError(err_msg)
 
     return weights, weight_switch
 

--- a/package/xentropy/kde.py
+++ b/package/xentropy/kde.py
@@ -27,8 +27,8 @@ class kde(object):
         # input
         # TODO preprocess and sanitycheck data here, too (code in dihedrals.py should be applicable)
         weights, weight_switch = process_weights_argument(weights, verbose=verbose)
-        self.__has_weights = weight_switch
         sanity_check_input_data(data, weights, weight_switch)
+        self.__has_weights = weight_switch
         check_dims(data)  # kde can only take single data sets currently
         self.__data = data
         self.__weights = weights
@@ -62,10 +62,12 @@ class kde(object):
         if verbose:
             print("Initializing C++ kernel for kde...")
         if self.has_weights:
+            # print(self.weights)  # DEBUG
             kernel = _kde_kernel(self.data, self.resolution, self.weights)
         else:
             kernel = _kde_kernel(self.data, self.resolution)
         kernel.calculate()
+        # print(kernel.get_pdf()) # DEBUG
         self.__is_finished = True
         if verbose:
             print("KDE finished.")


### PR DESCRIPTION
Supposed to fix #58 

I think throwing an error is the best option, if users give negative weights for the kde