### PR TITLE
Fix bug in normalizer

### DIFF
--- a/package/src/kde.cpp
+++ b/package/src/kde.cpp
@@ -5,7 +5,7 @@ double calcHistogramNormalizer(const std::vector<double> &weights)
     return 1.0 / std::accumulate(
         std::begin(weights),
         std::end(weights),
-        0
+        0.0
     );
 }
 

--- a/package/tests_cpp/KDE_Tester.cpp
+++ b/package/tests_cpp/KDE_Tester.cpp
@@ -44,5 +44,6 @@ TEST(GceTest, WeightsTest)
 TEST(calcHistogramNormalizer, Tests)
 {
     EXPECT_DOUBLE_EQ(calcHistogramNormalizer({1., 2., 3., 4., 5.}), 1. / 15.);
+    EXPECT_DOUBLE_EQ(calcHistogramNormalizer({0.5, 2.5, 3.15, 4.85, 5.}), 1. / 15.);
     EXPECT_DOUBLE_EQ(calcHistogramNormalizer(15), 1. / 15.);
 }

--- a/package/tests_cpp/KDE_Tester.cpp
+++ b/package/tests_cpp/KDE_Tester.cpp
@@ -44,6 +44,6 @@ TEST(GceTest, WeightsTest)
 TEST(calcHistogramNormalizer, Tests)
 {
     EXPECT_DOUBLE_EQ(calcHistogramNormalizer({1., 2., 3., 4., 5.}), 1. / 15.);
-    EXPECT_DOUBLE_EQ(calcHistogramNormalizer({0.5, 2.5, 3.15, 4.85, 5.}), 1. / 15.);
+    EXPECT_DOUBLE_EQ(calcHistogramNormalizer({0.5, 2.5, 3.15, 3.85, 5.}), 1. / 15.);
     EXPECT_DOUBLE_EQ(calcHistogramNormalizer(15), 1. / 15.);
 }


### PR DESCRIPTION
Due to the way std::accumulate decides which version is used (the initial value is the deciding factor), the sum was performed on integers, this leads to 0 values, when the parts of the sum are smaller 1. This should address and close #56 , and close #57.
Tests against this behavior should be added. Do not merge until I added these tests!