### PR TITLE
Migrate to main

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -2,9 +2,9 @@ name: C++:CMake
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
-    branches: [master]
+    branches: [main]
 
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -2,9 +2,9 @@ name: Python:Pip
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
-    branches: [master]
+    branches: [main]
 
 
 jobs:


### PR DESCRIPTION
In order to adhere to newer (already old, but still) standards, the name of the default branch has been changed to main. The master branch is thus deprecated and will be removed. This updates the workflows to use main instead of master.
Closes #66 